### PR TITLE
move defvar for *decode-data* and *png-object* to common.lisp

### DIFF
--- a/src/common.lisp
+++ b/src/common.lisp
@@ -12,7 +12,9 @@
 (deftype ub16a2d () '(simple-array ub16 (* *)))
 (deftype ub16a3d () '(simple-array ub16 (* * *)))
 
-(defvar *buffer* nil)
+(defvar *buffer*)
+(defvar *decode-data*)
+(defvar *png-object*)
 
 (defun get-path ()
   (let ((stream (fast-io::input-buffer-stream *buffer*)))

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -1,7 +1,5 @@
 (in-package :pngload)
 
-(defvar *decode-data* nil)
-
 (defun get-image-bytes ()
   (with-slots (width height interlace-method) *png-object*
     (ecase interlace-method

--- a/src/png.lisp
+++ b/src/png.lisp
@@ -1,7 +1,5 @@
 (in-package :pngload)
 
-(defvar *png-object* nil)
-
 (defclass png-object ()
   ((parse-tree :accessor parse-tree)
    (width :accessor width)


### PR DESCRIPTION
 * gets rid of undefined variable warning when compiling files that
   come before decode.lisp and png.lisp

 * also, since we rebind these variables (and *buffer*) the defvar
   form can leave them undefined, instead of setting them to nil. This
   should trigger an error if someone tries to use these without
   rebinding them.